### PR TITLE
PTS-57-Email-Copy

### DIFF
--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -10,9 +10,37 @@ const Footer = () => {
     const [copied, setCopied] = useState(false);
 
     const handleCopy = () => {
-        navigator.clipboard.writeText("info@parkingtime.se");
-        setCopied(true);
-        setTimeout(() => setCopied(false), 2000);
+        if (navigator.clipboard && navigator.clipboard.writeText) {
+            navigator.clipboard.writeText("info@parkingtime.se")
+                .then(() => {
+                    setCopied(true);
+                    setTimeout(() => setCopied(false), 2000); 
+                })
+                .catch(err => {
+                    console.error('Failed to copy: ', err);
+                    fallbackCopyTextToClipboard("info@parkingtime.se");
+                });
+        } else {
+            fallbackCopyTextToClipboard("info@parkingtime.se");
+        }
+    };
+
+    const fallbackCopyTextToClipboard = (text) => {
+        const textArea = document.createElement("textarea");
+        textArea.value = text;
+        textArea.style.position = "fixed";
+        textArea.style.top = "-9999px";
+        document.body.appendChild(textArea);
+        textArea.focus();
+        textArea.select();
+        try {
+            document.execCommand('copy');
+            setCopied(true);
+            setTimeout(() => setCopied(false), 2000); 
+        } catch (err) {
+            console.error('Fallback: Oops, unable to copy', err);
+        }
+        document.body.removeChild(textArea);
     };
 
     return (

--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -1,9 +1,20 @@
+"use client";
+
 import Image from "next/image";
 import ptLogo from '../../../public/pt-logo-v2.svg'
 import instagramIcon from '../../../public/Instagram.svg'
 import linkedInIcon from '../../../public/LinkedIn.svg'
+import { useState } from "react";
 
 const Footer = () => {
+    const [copied, setCopied] = useState(false);
+
+    const handleCopy = () => {
+        navigator.clipboard.writeText("info@parkingtime.se");
+        setCopied(true);
+        setTimeout(() => setCopied(false), 2000);
+    };
+
     return (
         <footer className="py-12 px-8 md:p-20 bg-pt-primary text-white gap-12 md:gap-5 flex flex-col font-mono">
             <div className="flex justify-between flex-col gap-12 md:gap-8 md:flex-row">
@@ -22,7 +33,10 @@ const Footer = () => {
                             <p className="font-normal underline cursor-pointer ">
                                 <a href="tel:+46 72 722 44 00">+46 72 722 44 00</a>
                             </p>
-                            <p className="font-normal underline cursor-pointer">info@parkingtime.se</p>
+                            <p className="font-normal underline cursor-pointer" onClick={handleCopy}>
+                                info@parkingtime.se
+                                {copied && <span className="ml-2 text-sm text-green-500">Copied!</span>}
+                            </p>
                         </div>
                         <div className="flex gap-3">
                             <a target="_blank" href="https://www.instagram.com/parkingtimesweden/">


### PR DESCRIPTION
**Make the email in Footer click to copy**

The navigator.clipboard API couldn't be supported in my mobile browser before so I added the fallback method so the email copying functionality should work across all devices, including those that do not support the Clipboard API.
